### PR TITLE
solve django.utils.translate.ugettext_lazy deprecation

### DIFF
--- a/src/locality/forms.py
+++ b/src/locality/forms.py
@@ -1,7 +1,10 @@
 from django.core.validators import EMPTY_VALUES
 from django.db.models import Q
 from django.forms import fields, ValidationError
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from locality.models import Country
 

--- a/src/locality/models.py
+++ b/src/locality/models.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from locality import managers
 


### PR DESCRIPTION
django.utils.translate.ugettext_lazy is deprecated in django3.0, will remove in django 4.0